### PR TITLE
fix: rename contentBase in webpack-config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const devServer = (isDev) => !isDev ? {} : {
         open: true,
         hot: true,
         port: 8080,
-        contentBase: path.join(__dirname, 'public'),
+        static: path.join(__dirname, 'public'),
     },
 };
   


### PR DESCRIPTION
rename "contentBase" to "static"